### PR TITLE
fix: stray closing br tags

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 env:
   SETTINGS_XML: ${{ github.workspace }}/.mvn/settings.xml
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
   JAVA_DISTRIBUTION: temurin
 jobs:
   build:

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,10 +1,6 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <activeProfiles>
-        <activeProfile>github</activeProfile>
-    </activeProfiles>
     <profiles>
-
         <profile>
             <id>deploy-github-packages</id>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,11 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>${sonar-maven-plugin.version}</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
 
         <maven-plugin-plugin.version>3.15.2</maven-plugin-plugin.version>
         <maven-plugin-annotations.version>3.13.1</maven-plugin-annotations.version>

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/links/ExternalLinkProcessor.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/links/ExternalLinkProcessor.java
@@ -5,14 +5,20 @@ import org.jetbrains.annotations.NotNull;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.jsoup.parser.Parser;
 import org.jsoup.select.Elements;
 
 public class ExternalLinkProcessor {
 
     public @NotNull String processExternalLinks(@NotNull String html) {
-        // Parse the HTML string into a Jsoup Document without altering the original formatting
-        Document document = Jsoup.parse(html, "", Parser.xmlParser());
+        // Parsed as an HTML body fragment, NOT as XML. To an XML parser a void element like <br> is
+        // merely unclosed, so everything after it becomes its child and all of them are closed at the
+        // end of the enclosing block - serializing as `text<br>more</br></br>`. A browser reads each
+        // stray </br> as another line break, so a paragraph carrying three soft breaks rendered with
+        // three extra blank lines after it.
+        Document document = Jsoup.parseBodyFragment(html);
+        // Keep the original formatting: pretty-printing re-indents and re-wraps the markup, which
+        // matters for whitespace-sensitive content such as <pre> code blocks.
+        document.outputSettings().prettyPrint(false);
 
         Elements links = document.select("a[href]");
 
@@ -25,8 +31,8 @@ public class ExternalLinkProcessor {
             }
         }
 
-        // Return the modified HTML as a string while preserving the original formatting
-        return document.outerHtml();
+        // Only the fragment that came in: parseBodyFragment wraps it in a full html/head/body document.
+        return document.body().html();
     }
 
     private static void addTargetAttribute(@NotNull Element link) {

--- a/src/test/java/ch/sbb/maven/plugins/markdown2html/links/ExternalLinkProcessorTest.java
+++ b/src/test/java/ch/sbb/maven/plugins/markdown2html/links/ExternalLinkProcessorTest.java
@@ -12,4 +12,17 @@ class ExternalLinkProcessorTest {
                 markdown -> new ExternalLinkProcessor().processExternalLinks(markdown));
     }
 
+    /**
+     * Void elements must survive untouched. Parsed as XML, a &lt;br&gt; is merely unclosed, so the rest
+     * of the block became its child and every one of them was closed at the end of it - emitting stray
+     * &lt;/br&gt; tags that a browser reads as further line breaks, one blank line each. Whitespace has
+     * to survive too: this step only adds a target attribute, it does not reformat the document.
+     */
+    @Test
+    @SuppressWarnings("java:S2699")
+    void testVoidElementsAndWhitespaceAreLeftIntact() {
+        TestCommons.runFunctionTestUsingFiles("links/html_with_void_elements.md", "links/html_with_void_elements_result.md",
+                html -> new ExternalLinkProcessor().processExternalLinks(html));
+    }
+
 }

--- a/src/test/resources/links/html_with_void_elements.md
+++ b/src/test/resources/links/html_with_void_elements.md
@@ -1,0 +1,8 @@
+<p>A paragraph the author wrapped across<br>
+three source lines, which GitHub renders<br>
+with a line break after each one.</p>
+<p>An <a href="https://example.org/spec">absolute link</a> and an <img src="logo.png" alt="">.</p>
+<pre><code>  indented   code
+    must not be re-wrapped
+</code></pre>
+<hr>

--- a/src/test/resources/links/html_with_void_elements_result.md
+++ b/src/test/resources/links/html_with_void_elements_result.md
@@ -1,0 +1,8 @@
+<p>A paragraph the author wrapped across<br>
+three source lines, which GitHub renders<br>
+with a line break after each one.</p>
+<p>An <a href="https://example.org/spec" target="_blank">absolute link</a> and an <img src="logo.png" alt="">.</p>
+<pre><code>  indented   code
+    must not be re-wrapped
+</code></pre>
+<hr>


### PR DESCRIPTION
### Proposed changes

This pull request updates the Java version used for builds and compilation to 21, and improves the handling of HTML fragments in the `ExternalLinkProcessor` to better preserve void elements and whitespace. It also adds a regression test to ensure these behaviors are maintained.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
