### PR TITLE
fix: central sources and javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -430,12 +430,6 @@
             <id>central-publishing</id>
             <build>
                 <plugins>
-                    <!--
-                        Maven Central rejects a deployment without them: "Sources must be provided but not
-                        found in entries". Only the publishing profile builds them - they are of no use to
-                        the other builds, and the workflow that deploys to GitHub Packages skips them with
-                        maven.source.skip and maven.javadoc.skip.
-                    -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,8 @@
         <visual.baseline.update>false</visual.baseline.update>
 
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+        <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
 
         <!-- Sonar and JaCoCo -->
@@ -428,6 +430,38 @@
             <id>central-publishing</id>
             <build>
                 <plugins>
+                    <!--
+                        Maven Central rejects a deployment without them: "Sources must be provided but not
+                        found in entries". Only the publishing profile builds them - they are of no use to
+                        the other builds, and the workflow that deploys to GitHub Packages skips them with
+                        maven.source.skip and maven.javadoc.skip.
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>


### PR DESCRIPTION
### Proposed changes

This pull request updates the Maven build configuration to enhance the publishing process, specifically for the `central-publishing` profile. The most important changes are the addition of plugins to automatically generate and attach source and Javadoc JARs during the build. This is a common requirement for publishing artifacts to Maven Central.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
