### PR TITLE
refactor: pass Route::abort as a method reference

### DIFF
--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/MarkdownToHtmlMojo.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/MarkdownToHtmlMojo.java
@@ -20,10 +20,22 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
 
+/**
+ * Converts a Markdown file into HTML, the way GitHub renders one.
+ * <p>
+ * Rendering happens in this process, so the build needs no network and no token for it. The parameters below
+ * cut the parts of the document that belong to whoever builds the project rather than to whoever reads the
+ * page, colour the code, and dress the result for wherever it is going to be embedded.
+ */
 @SuppressWarnings("unused")
 @Slf4j
 @Mojo(name = "convert", defaultPhase = LifecyclePhase.GENERATE_RESOURCES)
 public class MarkdownToHtmlMojo extends AbstractMojo {
+
+    /** Creates the mojo. Maven does this and fills the parameters in; nothing else should. */
+    public MarkdownToHtmlMojo() {
+        // Nothing to set up
+    }
 
     @Parameter(property = "inputFile", defaultValue = "${project.basedir}/README.md")
     private File inputFile;

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/alert/AlertBlock.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/alert/AlertBlock.java
@@ -1,16 +1,22 @@
 package ch.sbb.maven.plugins.markdown2html.alert;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.commonmark.node.CustomBlock;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A blockquote whose first line marked it as one of GitHub's alerts. It holds what was left of the quote
  * after the marker was taken off.
  */
 @Getter
-@RequiredArgsConstructor
 public class AlertBlock extends CustomBlock {
 
     private final GitHubAlert alert;
+
+    /**
+     * @param alert the kind of alert the marker named
+     */
+    public AlertBlock(@NotNull GitHubAlert alert) {
+        this.alert = alert;
+    }
 }

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/alert/GitHubAlert.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/alert/GitHubAlert.java
@@ -16,18 +16,23 @@ import java.util.Locale;
 @RequiredArgsConstructor
 public enum GitHubAlert {
 
+    /** Something worth knowing even when skimming. */
     NOTE("Note", "info",
             "M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"),
 
+    /** Advice on doing something better or more easily. */
     TIP("Tip", "light-bulb",
             "M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z"),
 
+    /** What a reader has to know to get where they are going. */
     IMPORTANT("Important", "report",
             "M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"),
 
+    /** Something needing attention now, to avoid trouble. */
     WARNING("Warning", "alert",
             "M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"),
 
+    /** A risk, or what an action will cost. */
     CAUTION("Caution", "stop",
             "M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z");
 
@@ -40,8 +45,10 @@ public enum GitHubAlert {
     private final String path;
 
     /**
-     * @return the alert a blockquote marked with {@code [!NOTE]} and the like opens with, or {@code null}
-     * when the marker names none of them
+     * Reads the marker that opens a blockquote.
+     *
+     * @param marker the first line of the quote, as written
+     * @return the alert it names, or {@code null} when it names none of them
      */
     public static @Nullable GitHubAlert ofMarker(@NotNull String marker) {
         if (!marker.startsWith("[!") || !marker.endsWith("]")) {
@@ -56,10 +63,16 @@ public enum GitHubAlert {
         return null;
     }
 
+    /**
+     * @return the class github-markdown-css styles this kind of alert by
+     */
     public @NotNull String getCssClass() {
         return "markdown-alert-" + name().toLowerCase(Locale.ROOT);
     }
 
+    /**
+     * @return the octicon GitHub puts in front of the title, as inline SVG
+     */
     public @NotNull String getIcon() {
         return ICON.formatted(octicon, path);
     }

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/alert/GitHubAlertsExtension.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/alert/GitHubAlertsExtension.java
@@ -30,9 +30,7 @@ import java.util.Set;
  */
 public class GitHubAlertsExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension {
 
-    /**
-     * @return the extension, to hand to the parser and the renderer alike
-     */    /** Creates the extension. Prefer {@link #create()}, which is what commonmark-java expects. */
+    /** Creates the extension. Prefer {@link #create()}, which is what commonmark-java expects. */
     public GitHubAlertsExtension() {
         // Nothing to set up
     }

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/alert/GitHubAlertsExtension.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/alert/GitHubAlertsExtension.java
@@ -30,6 +30,16 @@ import java.util.Set;
  */
 public class GitHubAlertsExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRendererExtension {
 
+    /**
+     * @return the extension, to hand to the parser and the renderer alike
+     */    /** Creates the extension. Prefer {@link #create()}, which is what commonmark-java expects. */
+    public GitHubAlertsExtension() {
+        // Nothing to set up
+    }
+
+    /**
+     * @return the extension, to hand to the parser and the renderer alike
+     */
     public static Extension create() {
         return new GitHubAlertsExtension();
     }

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/highlight/CodeHighlighter.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/highlight/CodeHighlighter.java
@@ -85,10 +85,17 @@ public class CodeHighlighter {
     );
 
     /**
+     * Colours a code block, or leaves it as it is when nothing can be made of its language.
+     *
      * @param code     the body of the code block, exactly as written
      * @param language the language after the opening fence, if any
      * @return the code as HTML - coloured when the language is one of the known ones, plain otherwise
      */
+    /** Creates a highlighter. It keeps nothing between the blocks it is given. */
+    public CodeHighlighter() {
+        // Nothing to set up
+    }
+
     public @NotNull String highlight(@NotNull String code, @Nullable String language) {
         String syntaxStyle = language == null ? null : LANGUAGES.get(language.toLowerCase(Locale.ROOT));
         if (syntaxStyle == null) {

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/highlight/CodeHighlighter.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/highlight/CodeHighlighter.java
@@ -84,6 +84,11 @@ public class CodeHighlighter {
             Map.entry("zsh", SyntaxConstants.SYNTAX_STYLE_UNIX_SHELL)
     );
 
+    /** Creates a highlighter. It keeps nothing between the blocks it is given. */
+    public CodeHighlighter() {
+        // Nothing to set up
+    }
+
     /**
      * Colours a code block, or leaves it as it is when nothing can be made of its language.
      *
@@ -91,11 +96,6 @@ public class CodeHighlighter {
      * @param language the language after the opening fence, if any
      * @return the code as HTML - coloured when the language is one of the known ones, plain otherwise
      */
-    /** Creates a highlighter. It keeps nothing between the blocks it is given. */
-    public CodeHighlighter() {
-        // Nothing to set up
-    }
-
     public @NotNull String highlight(@NotNull String code, @Nullable String language) {
         String syntaxStyle = language == null ? null : LANGUAGES.get(language.toLowerCase(Locale.ROOT));
         if (syntaxStyle == null) {

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/html/HtmlProcessor.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/html/HtmlProcessor.java
@@ -9,10 +9,27 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Gives every heading an id, so that a table of contents or a link from elsewhere can point at it. GitHub
+ * does this on its own pages; the markup its API returns carries none.
+ * <p>
+ * An id is the heading text, transliterated to ASCII and lowercased. One instance keeps the ids it has
+ * handed out, so a heading whose text repeats gets a number, and holds them only for the document it was
+ * used on.
+ */
 public class HtmlProcessor {
 
     private final Set<String> usedHeadingIds = new HashSet<>();
 
+    /** Creates a processor. Use one per document: it remembers the ids it has handed out. */
+    public HtmlProcessor() {
+        // Nothing to set up
+    }
+
+    /**
+     * @param html the rendered document
+     * @return the same markup, with an id on every heading that had none
+     */
     public @NotNull String addHeadingIds(@NotNull String html) {
         Pattern pattern = Pattern.compile("<(?<tag>h[1-6])>(?<text>.*?)</\\k<tag>>", Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(html);

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/html/StylesheetEmbedder.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/html/StylesheetEmbedder.java
@@ -21,8 +21,19 @@ public class StylesheetEmbedder {
     private static final String STYLESHEET = "github-markdown-light.css";
     private static final String CONTENT_CLASS = "markdown-body";
 
-    // The newlines are HTML the generated file carries, not console output, so they stay "\n" on every
-    // platform - which is also why this is concatenated rather than formatted.
+    /** Creates an embedder. The stylesheet is read from the plugin on each call. */
+    public StylesheetEmbedder() {
+        // Nothing to set up
+    }
+
+    /**
+     * The newlines are HTML the generated file carries, not console output, so they stay {@code \n} on
+     * every platform - which is also why this is concatenated rather than formatted.
+     *
+     * @param html the rendered document
+     * @return the document wrapped in the stylesheet and in the class its rules are scoped to
+     * @throws IOException if the stylesheet cannot be read out of the plugin
+     */
     public @NotNull String embed(@NotNull String html) throws IOException {
         return "<style>\n" + readStylesheet() + "</style>\n"
                 + "<div class=\"" + CONTENT_CLASS + "\">\n" + html + "</div>\n";

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/images/ImageProcessingType.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/images/ImageProcessingType.java
@@ -1,6 +1,13 @@
 package ch.sbb.maven.plugins.markdown2html.images;
 
+/**
+ * What the plugin does with the images a document points at.
+ */
 public enum ImageProcessingType {
+
+    /** Leaves every image where it is, so the generated file keeps pointing at it. */
     NONE,
+
+    /** Reads each image and writes it into the file as a data URI, so it carries its own pictures. */
     EMBED
 }

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/images/ImagesProcessor.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/images/ImagesProcessor.java
@@ -8,10 +8,24 @@ import java.util.Base64;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+/**
+ * Deals with the pictures a document points at: either makes their addresses absolute, or reads them and
+ * writes them into the document, so that the generated file carries them and needs nothing else.
+ */
 public class ImagesProcessor {
 
     private static final String DEFAULT_IMAGE_MIME_TYPE = "image/*";
 
+    /** Creates a processor. It keeps nothing between the documents it is given. */
+    public ImagesProcessor() {
+        // Nothing to set up
+    }
+
+    /**
+     * @param markdown           the document to rewrite
+     * @param relativeLinkPrefix what to put in front of an image address that points inside the repository
+     * @return the document, with every relative image address made absolute
+     */
     public @NotNull String processRelativeUrls(@NotNull String markdown, @NotNull String relativeLinkPrefix) {
         String markdownLinkPattern = "!\\[(?<text>[^]]*)]\\((?<url>[^)]+)\\)";
         return Pattern.compile(markdownLinkPattern)
@@ -19,6 +33,13 @@ public class ImagesProcessor {
                 .replaceAll(match -> "![%s](%s)".formatted(match.group(1), Utils.replaceRelativeUrl(match.group(2), relativeLinkPrefix)));
     }
 
+    /**
+     * Replaces the address of every image with the picture itself, as a data URI. An address that names a
+     * file is read from disk, an absolute one is fetched.
+     *
+     * @param html the rendered document
+     * @return the same markup, carrying its pictures
+     */
     public @NotNull String embedImages(@NotNull String html) {
         String imgSrcPattern = "<img[^<>]* src=([\"'])(?<url>[^(\"|')]*)([\"'])";
         return Pattern.compile(imgSrcPattern)

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/links/ExternalLinkProcessor.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/links/ExternalLinkProcessor.java
@@ -7,8 +7,22 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
+/**
+ * Makes the links that leave the document open in a new tab, so that a reader following one does not lose
+ * the page it is embedded in.
+ */
 public class ExternalLinkProcessor {
+    /** Creates a processor. It keeps nothing between the documents it is given. */
+    public ExternalLinkProcessor() {
+        // Nothing to set up
+    }
 
+
+    /**
+     * @param html the rendered document
+     * @return the same markup, with {@code target="_blank"} on every absolute link that did not carry a
+     * target already
+     */
     public @NotNull String processExternalLinks(@NotNull String html) {
         // Parsed as an HTML body fragment, NOT as XML. To an XML parser a void element like <br> is
         // merely unclosed, so everything after it becomes its child and all of them are closed at the

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/links/RelativeLinksProcessor.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/links/RelativeLinksProcessor.java
@@ -5,8 +5,26 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.regex.Pattern;
 
+/**
+ * Puts a prefix in front of the links that point inside the repository. Read anywhere else than on the
+ * repository page, a relative link leads nowhere, so it is turned into an absolute one.
+ * <p>
+ * Images are left alone here - {@link ch.sbb.maven.plugins.markdown2html.images.ImagesProcessor} handles
+ * those, since they may be embedded instead.
+ */
 public class RelativeLinksProcessor {
+    /** Creates a processor. It keeps nothing between the documents it is given. */
+    public RelativeLinksProcessor() {
+        // Nothing to set up
+    }
 
+
+    /**
+     * @param markdown           the document to rewrite
+     * @param relativeLinkPrefix what to put in front of a relative destination; a trailing slash is added
+     *                           if it has none
+     * @return the document, with every relative link made absolute
+     */
     public @NotNull String processRelativeLinks(@NotNull String markdown, @NotNull String relativeLinkPrefix) {
         String markdownLinkPattern = "(?<!!)\\[(?<text>[^]]*)]\\((?<url>[^)]+)\\)";
         return Pattern.compile(markdownLinkPattern)

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/markdown/MarkdownProcessor.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/markdown/MarkdownProcessor.java
@@ -8,9 +8,26 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Takes parts out of a document before it is rendered. A README carries sections that belong to whoever
+ * builds the project - how to compile it, how to install it, its changelog - and not to whoever reads the
+ * page it ends up on.
+ * <p>
+ * Everything here leaves the document untouched when given nothing to remove.
+ */
 @Slf4j
 public class MarkdownProcessor {
+    /** Creates a processor. It keeps nothing between the documents it is given. */
+    public MarkdownProcessor() {
+        // Nothing to set up
+    }
 
+
+    /**
+     * @param markdown        the document to cut
+     * @param excludeChapters the headings to remove, each with its own text, as in {@code ## Build}
+     * @return the document without those chapters
+     */
     public @NotNull String removeChapter(@NotNull String markdown, @Nullable List<String> excludeChapters) {
         if (excludeChapters == null) {
             return markdown;
@@ -25,6 +42,14 @@ public class MarkdownProcessor {
         return markdown;
     }
 
+    /**
+     * Removes one chapter: its heading and everything under it, up to the next heading of the same level or
+     * higher.
+     *
+     * @param markdown     the document to cut
+     * @param chapterTitle the heading to remove, with its own text, as in {@code ## Build}
+     * @return the document without that chapter
+     */
     public @NotNull String removeChapter(@NotNull String markdown, @Nullable String chapterTitle) {
         if (chapterTitle == null || chapterTitle.isEmpty()) {
             return markdown;
@@ -47,6 +72,11 @@ public class MarkdownProcessor {
         return result.replaceAll("(?m)^\\s*\\R", "\n").trim();
     }
 
+    /**
+     * @param markdown       the document to cut
+     * @param lineSubstrings the texts to look for; a line holding any of them goes
+     * @return the document without those lines
+     */
     public @NotNull String removeLinesContainingSubstrings(@NotNull String markdown, @Nullable List<String> lineSubstrings) {
         if (lineSubstrings == null) {
             return markdown;
@@ -61,6 +91,11 @@ public class MarkdownProcessor {
         return markdown;
     }
 
+    /**
+     * @param markdown   the document to cut
+     * @param linePrefix the text to look for; a line holding it goes, wherever in the line it sits
+     * @return the document without those lines
+     */
     public @NotNull String removeLinesWithSubstring(@NotNull String markdown, @Nullable String linePrefix) {
         if (linePrefix == null || linePrefix.isEmpty()) {
             return markdown;
@@ -69,6 +104,11 @@ public class MarkdownProcessor {
         return markdown.replaceAll("(?m)^.*" + Pattern.quote(linePrefix) + ".*(\\R|)", "");
     }
 
+    /**
+     * @param markdown     the document to cut
+     * @param linePatterns the regular expressions to match; what any of them matches goes
+     * @return the document without what they matched
+     */
     public @NotNull String removeLinesUsingRegExPatterns(@NotNull String markdown, @Nullable List<String> linePatterns) {
         if (linePatterns == null) {
             return markdown;
@@ -83,6 +123,11 @@ public class MarkdownProcessor {
         return markdown;
     }
 
+    /**
+     * @param markdown    the document to cut
+     * @param linePattern the regular expression to match; what it matches goes
+     * @return the document without what it matched
+     */
     public @NotNull String removeLinesWithPattern(@NotNull String markdown, @Nullable String linePattern) {
         if (linePattern == null) {
             return markdown;

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/markdown/MarkdownRenderer.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/markdown/MarkdownRenderer.java
@@ -41,11 +41,16 @@ public class MarkdownRenderer {
     private final Parser parser;
     private final HtmlRenderer renderer;
 
+    /**
+     * Renders with the syntax of fenced code blocks coloured in.
+     */
     public MarkdownRenderer() {
         this(true);
     }
 
     /**
+     * Renders with the syntax colouring switched as asked.
+     *
      * @param highlightCode whether fenced code blocks with a known language get their syntax coloured in
      */
     public MarkdownRenderer(boolean highlightCode) {
@@ -72,6 +77,10 @@ public class MarkdownRenderer {
         renderer = builder.build();
     }
 
+    /**
+     * @param markdown the document to render
+     * @return it as HTML, ending with a newline unless there was nothing to render
+     */
     public @NotNull String render(@NotNull String markdown) {
         Node document = parser.parse(markdown);
         // jsoup drops the newline the renderer puts after the last block; it is restored so that the

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/util/Resource.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/util/Resource.java
@@ -1,13 +1,26 @@
 package ch.sbb.maven.plugins.markdown2html.util;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import org.jetbrains.annotations.Nullable;
 
+/**
+ * Something read from a file or fetched over the network, together with what it is.
+ */
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class Resource {
-    private byte[] content;
-    private String mimeType;
+
+    /** The bytes themselves. */
+    private final byte[] content;
+
+    /** What they are, as the server or the file system reported it; {@code null} when neither could tell. */
+    private final String mimeType;
+
+    /**
+     * @param content  the bytes that were read
+     * @param mimeType what they are, or {@code null} when whoever handed them over did not say
+     */
+    public Resource(byte[] content, @Nullable String mimeType) {
+        this.content = content;
+        this.mimeType = mimeType;
+    }
 }

--- a/src/main/java/ch/sbb/maven/plugins/markdown2html/util/Utils.java
+++ b/src/main/java/ch/sbb/maven/plugins/markdown2html/util/Utils.java
@@ -1,7 +1,6 @@
 package ch.sbb.maven.plugins.markdown2html.util;
 
 import lombok.SneakyThrows;
-import lombok.experimental.UtilityClass;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -13,10 +12,24 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.nio.file.Files;
 
-@UtilityClass
-public class Utils {
+/**
+ * The odds and ends the processors share: telling an address that leaves the repository from one that stays
+ * inside it, and reading what either of them points at.
+ */
+public final class Utils {
 
-    public String replaceRelativeUrl(String url, String prefix) {
+    private Utils() {
+        // Nothing to instantiate; lombok's @UtilityClass would hide the constructor from javadoc, which
+        // then reports a public default one this class does not have
+    }
+
+    /**
+     * @param url    the address to look at
+     * @param prefix what to put in front of it, with or without a trailing slash
+     * @return the address made absolute, or the address itself when it already was, or when it points
+     * within the same page
+     */
+    public static String replaceRelativeUrl(String url, String prefix) {
         // Check if the URL is neither absolute (starts with http/https) nor internal (starts with #)
         if (!isAbsoluteUrl(url) && !url.startsWith("#")) {
             // Ensure relativeLinkPrefix ends with /
@@ -34,12 +47,21 @@ public class Utils {
         return url;
     }
 
-    public boolean isAbsoluteUrl(String url) {
+    /**
+     * @param url the address to look at
+     * @return whether it names a host of its own rather than a place in the repository
+     */
+    public static boolean isAbsoluteUrl(String url) {
         return url.matches("^(http|https|ftp)://.*");
     }
 
+    /**
+     * @param url what to fetch
+     * @return what came back, with the content type the server gave it
+     * @throws IllegalStateException if the server answered with anything but 200
+     */
     @SneakyThrows
-    public Resource getResourceByURL(String url) {
+    public static Resource getResourceByURL(String url) {
         try (CloseableHttpClient client = HttpClients.createDefault()) {
             HttpGet request = new HttpGet(url);
             HttpClientResponseHandler<Resource> responseHandler = response -> {
@@ -54,8 +76,13 @@ public class Utils {
         }
     }
 
+    /**
+     * @param path the file to read
+     * @return its bytes, with the content type guessed from it
+     * @throws java.io.FileNotFoundException if there is no such file
+     */
     @SneakyThrows
-    public Resource getResourceByPath(String path) {
+    public static Resource getResourceByPath(String path) {
         File file = new File(path);
         if (!file.exists() || !file.isFile()) {
             throw new FileNotFoundException("File not found: " + path);

--- a/src/visual-test/java/ch/sbb/maven/plugins/markdown2html/github/VisualBaselineTest.java
+++ b/src/visual-test/java/ch/sbb/maven/plugins/markdown2html/github/VisualBaselineTest.java
@@ -6,6 +6,7 @@ import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.Route;
 import lombok.SneakyThrows;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -89,7 +90,7 @@ class VisualBaselineTest {
                     .newPage();
             // The fixture names no remote asset, and a request leaving the container would make the
             // picture depend on the day
-            page.route("**", route -> route.abort());
+            page.route("**", Route::abort);
 
             page.setContent(readResource("visual/shell.html")
                     .replace("{{content}}", embed(html))

--- a/src/visual-test/java/ch/sbb/maven/plugins/markdown2html/github/VisualParityTest.java
+++ b/src/visual-test/java/ch/sbb/maven/plugins/markdown2html/github/VisualParityTest.java
@@ -6,6 +6,7 @@ import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.Route;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
@@ -85,7 +86,7 @@ class VisualParityTest {
                     .newPage();
             // Nothing may be fetched: the camo URLs GitHub returns are not the ones the local renderer
             // keeps, and a network round trip would make the screenshots depend on the day
-            page.route("**", route -> route.abort());
+            page.route("**", Route::abort);
 
             ScreenshotComparison comparison = ScreenshotComparison.of(screenshot(page, githubHtml), screenshot(page, localHtml));
             comparison.writeTo(ARTIFACTS);


### PR DESCRIPTION
### Proposed changes

Both visual tests block the browser's requests with a lambda that does nothing but call the method it is handed.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
